### PR TITLE
Remove the empty line form ignored committers list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+node_modules

--- a/cli/commands/index.js
+++ b/cli/commands/index.js
@@ -30,7 +30,9 @@ async function chooseReviewers(
 ) {
   let spinner = ora(`Getting changed files since "${branch}"`).start();
   let username = await getActiveUserName();
-  let ignoreList = [username].concat(ignore.split(","));
+  let ignoreList = [username]
+      .concat(ignore.split(","))
+      .filter(ignored => !!ignored);
   let changedFiles = await getChangedFiles({
     mainBranch: branch,
     customGetDiffPoint: undefined,

--- a/commands/index.js
+++ b/commands/index.js
@@ -26,7 +26,9 @@ export default async function chooseReviewers(
 ) {
   let spinner = ora(`Getting changed files since "${branch}"`).start();
   let username = await getActiveUserName();
-  let ignoreList = [username].concat(ignore.split(","));
+  let ignoreList = [username]
+      .concat(ignore.split(","))
+      .filter(ignored => !!ignored);
   let changedFiles = await getChangedFiles({
     mainBranch: branch,
     customGetDiffPoint: undefined,


### PR DESCRIPTION
This results in an `item[0].includes('')` which is always true so every comitter was filtered out